### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.kevinresol.react_native_sound_recorder">
 
 </manifest>
   


### PR DESCRIPTION
`com.reactlibrary` is a common use package name and we have conflict error `more than one library with package name 'com.reactlibrary'`

see https://github.com/craftzdog/react-native-sqlite-2/pull/21 for example