### PR TITLE
Add requiresMainQueueSetup method

### DIFF
--- a/ios/RNSoundRecorder.m
+++ b/ios/RNSoundRecorder.m
@@ -66,6 +66,11 @@ RCT_EXPORT_MODULE()
     };
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_METHOD(start:(NSString *)path
                   options:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
Since RN 0.49, requiresMainQueueSetup needs to be defined if the module overrides constantsToExport.

Without this method you will get warning like this:
![img_8597](https://user-images.githubusercontent.com/839922/44031165-c7cc29bc-9f0b-11e8-9180-9f3fa0fb7fa0.PNG)
