### PR TITLE
Handle exception on the start of recording

### DIFF
--- a/android/src/main/java/com/kevinresol/react_native_sound_recorder/RNSoundRecorderModule.java
+++ b/android/src/main/java/com/kevinresol/react_native_sound_recorder/RNSoundRecorderModule.java
@@ -119,6 +119,8 @@ public class RNSoundRecorderModule extends ReactContextBaseJavaModule {
       promise.resolve(null);
     } catch (IOException e) {
       promise.reject("recording_failed", "Cannot record audio at path: " + path);
+    } catch (IllegalStateException e) {
+      promise.reject("recording_failed", "Microphone is already in use by another app.");
     }
   }
 


### PR DESCRIPTION
`IllegalStateException` isn't being caught and propagated to react-native via rejected promise which causes application to crash.