### PR TITLE
Allow recording while other media playing

### DIFF
--- a/ios/RNSoundRecorder.m
+++ b/ios/RNSoundRecorder.m
@@ -170,7 +170,14 @@ RCT_EXPORT_METHOD(stop:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejec
     
     // deactivate the audio session
     AVAudioSession* session = [AVAudioSession sharedInstance];
-    [session setActive:NO error:nil];
+    [session setActive:NO error:&err];
+    
+    if (err && [err code] != AVAudioSessionErrorCodeIsBusy) {
+        _rejectStop(@"session_set_active_error", [[err userInfo] description], err);
+        return;
+    }
+    
+    err = nil;
     
     [session setCategory:AVAudioSessionCategoryPlayback error:&err];
     

--- a/ios/RNSoundRecorder.m
+++ b/ios/RNSoundRecorder.m
@@ -110,7 +110,7 @@ RCT_EXPORT_METHOD(start:(NSString *)path
     NSError* err = nil;
 
     AVAudioSession* session = [AVAudioSession sharedInstance];
-    [session setCategory:AVAudioSessionCategoryRecord error:&err];
+    [session setCategory:AVAudioSessionCategoryPlayAndRecord error:&err];
     
     if (err) {
         reject(@"init_session_error", [[err userInfo] description], err);
@@ -170,12 +170,7 @@ RCT_EXPORT_METHOD(stop:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejec
     
     // deactivate the audio session
     AVAudioSession* session = [AVAudioSession sharedInstance];
-    [session setActive:NO error:&err];
-    
-    if (err) {
-        _rejectStop(@"session_set_active_error", [[err userInfo] description], err);
-        return;
-    }
+    [session setActive:NO error:nil];
     
     [session setCategory:AVAudioSessionCategoryPlayback error:&err];
     


### PR DESCRIPTION
Using AVAudioSessionCategoryPlayAndRecord is possibile to have other media playing (for example a muted video).

If we have another active media (for example a video) and we try to terminate the AVAudioSession we have an error.
And if we have an error, rejectStop is called and we lose the recording.
We could just try to deactivate the AVAudioSession, but if this is not possible, we shouldn't make fail the recording entirely.